### PR TITLE
Gulpfile Sassdoc Task Created

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,11 @@ gulp.task('serve', ['build'], function(){
   $.browserSync.init({server: './dist', port: port});
 });
 
+// Starts a BrowerSync instance for the docs
+gulp.task('serve:docs', function(){
+  $.browserSync.init({server: './docs', port: port});
+});
+
 // Watch files for changes
 gulp.task('watch', function() {
   gulp.watch('assets/scss/**/*.scss', ['sass', $.browserSync.reload]);
@@ -23,5 +28,14 @@ gulp.task('watch', function() {
   gulp.watch('dist/index.html', [$.browserSync.reload]);
 });
 
+// Watch files for changes
+gulp.task('watch:docs', function() {
+  gulp.watch('assets/scss/**/*.scss', ['sassdoc']);
+  gulp.watch('docs/index.html', $.browserSync.reload);
+});
+
 // Runs all of the above tasks and then waits for files to change
 gulp.task('default', ['serve', 'watch']);
+
+// Runs the same tasks but is specifically used for working on documentation
+gulp.task('docs', ['serve:docs', 'watch:docs']);


### PR DESCRIPTION
This creates a new run task aside from default. It primarily focuses on the sassdoc compilation. It serves the documents directory to browsersync and watches for changes in the sass files. Note that any changes to non-documentation related content will not appear as it only references the annotated comments in the generated docs index.html file.
